### PR TITLE
feat(auth,users): implement auth and user functionality 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,9 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+
+# Backend specific
+backend/.venv/
+backend/.env
+backend/src/*.egg-info/

--- a/backend/src/app/api/v1/routes.py
+++ b/backend/src/app/api/v1/routes.py
@@ -1,8 +1,13 @@
+"""Top-level API router for version 1 endpoints."""
+
 from fastapi import APIRouter
-from app.routes.health import router as health_router
+
 from app.routes.auth import router as auth_router
+from app.routes.health import router as health_router
+from app.routes.users import router as users_router
 
 api_router = APIRouter()
 
-api_router.include_router(health_router, tags=["health"])
+api_router.include_router(health_router, prefix="/health", tags=["health"])
 api_router.include_router(auth_router, prefix="/auth", tags=["auth"])
+api_router.include_router(users_router, prefix="/users", tags=["users"])

--- a/backend/src/app/core/auth.py
+++ b/backend/src/app/core/auth.py
@@ -1,0 +1,89 @@
+"""Authentication helpers for password hashing and JWT handling."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.settings import settings
+from app.models.user import User
+from app.repository.user import get_user_by_id
+
+# Password hashing context.
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Reads Authorization: Bearer <token>
+bearer_scheme = HTTPBearer()
+
+
+def hash_password(password: str) -> str:
+    """Hash a plain-text password before storing it."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plain-text password against its hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(user_id: str, role: str) -> str:
+    """Create a signed JWT for the given user."""
+    expire = datetime.now(timezone.utc) + timedelta(
+        minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES,
+    )
+    payload = {
+        "sub": user_id,
+        "role": role,
+        "exp": expire,
+    }
+    return jwt.encode(
+        payload,
+        settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+
+def decode_access_token(token: str) -> dict:
+    """Decode and validate a JWT."""
+    try:
+        return jwt.decode(
+            token,
+            settings.JWT_SECRET,
+            algorithms=[settings.JWT_ALGORITHM],
+        )
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        ) from exc
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    """Resolve the authenticated user from the Bearer token."""
+    token = credentials.credentials
+    payload = decode_access_token(token)
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+        )
+
+    user = get_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+
+    return user

--- a/backend/src/app/core/dependencies.py
+++ b/backend/src/app/core/dependencies.py
@@ -1,0 +1,34 @@
+"""Reusable authorization dependencies and helpers."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.models.user import User, UserRole
+
+
+def require_same_user(path_user_id: str, current_user: User) -> None:
+    """Ensure a user may only modify their own account."""
+    if current_user.id != path_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only modify your own account",
+        )
+
+
+def require_buyer(current_user: User) -> None:
+    """Ensure the current user is a buyer."""
+    if current_user.role != UserRole.BUYER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Buyer role required",
+        )
+
+
+def require_seller(current_user: User) -> None:
+    """Ensure the current user is a seller."""
+    if current_user.role != UserRole.SELLER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Seller role required",
+        )

--- a/backend/src/app/models/user.py
+++ b/backend/src/app/models/user.py
@@ -1,0 +1,49 @@
+"""SQLAlchemy user model for authentication and profile data."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Enum, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class UserRole(str, enum.Enum):
+    """Allowed user roles in the system."""
+
+    BUYER = "buyer"
+    SELLER = "seller"
+
+
+class User(Base):
+    """Database model for application users."""
+
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    role: Mapped[UserRole] = mapped_column(Enum(UserRole), nullable=False)
+    bio: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/backend/src/app/repository/user.py
+++ b/backend/src/app/repository/user.py
@@ -1,0 +1,50 @@
+"""Database access functions for users."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.schemas.user import UserRegister, UserUpdate
+
+
+def get_user_by_email(db: Session, email: str) -> User | None:
+    """Return a user by email, or None if not found."""
+    return db.query(User).filter(User.email == email).first()
+
+
+def get_user_by_id(db: Session, user_id: str) -> User | None:
+    """Return a user by ID, or None if not found."""
+    return db.query(User).filter(User.id == user_id).first()
+
+
+def create_user(db: Session, user_data: UserRegister, password_hash: str) -> User:
+    """Create and persist a new user."""
+    db_user = User(
+        name=user_data.name,
+        email=user_data.email,
+        password_hash=password_hash,
+        role=user_data.role,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def update_user(db: Session, db_user: User, update_data: UserUpdate) -> User:
+    """Apply partial updates to a user and persist changes."""
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    for field, value in update_dict.items():
+        setattr(db_user, field, value)
+
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def delete_user(db: Session, db_user: User) -> None:
+    """Delete a user from the database."""
+    db.delete(db_user)
+    db.commit()

--- a/backend/src/app/routes/auth.py
+++ b/backend/src/app/routes/auth.py
@@ -1,7 +1,53 @@
-from fastapi import APIRouter
+"""Authentication routes for registering and logging in users."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.auth import create_access_token, hash_password, verify_password
+from app.core.database import get_db
+from app.repository.user import create_user, get_user_by_email
+from app.schemas.user import AuthResponse, UserLogin, UserRegister
 
 router = APIRouter()
 
-@router.post("/register")
-def register():
-    return {"success": True, "message": "register route stub"}
+
+@router.post("/register", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
+def register(user_data: UserRegister, db: Session = Depends(get_db)) -> AuthResponse:
+    """Register a new buyer or seller and return a JWT."""
+    existing_user = get_user_by_email(db, user_data.email)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email is already registered",
+        )
+
+    password_hash = hash_password(user_data.password)
+    db_user = create_user(db, user_data, password_hash)
+    token = create_access_token(db_user.id, db_user.role.value)
+
+    return AuthResponse(
+        success=True,
+        token=token,
+        user=db_user,
+    )
+
+
+@router.post("/login", response_model=AuthResponse, status_code=status.HTTP_200_OK)
+def login(user_data: UserLogin, db: Session = Depends(get_db)) -> AuthResponse:
+    """Authenticate a user and return a JWT."""
+    db_user = get_user_by_email(db, user_data.email)
+    if not db_user or not verify_password(user_data.password, db_user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+
+    token = create_access_token(db_user.id, db_user.role.value)
+
+    return AuthResponse(
+        success=True,
+        token=token,
+        user=db_user,
+    )

--- a/backend/src/app/routes/users.py
+++ b/backend/src/app/routes/users.py
@@ -1,0 +1,76 @@
+"""User profile routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_current_user
+from app.core.database import get_db
+from app.core.dependencies import require_same_user
+from app.models.user import User
+from app.repository.user import delete_user, get_user_by_email, get_user_by_id, update_user
+from app.schemas.user import MessageResponse, UserPublic, UserUpdate, UserUpdateResponse
+
+router = APIRouter()
+
+
+@router.get("/{id}", response_model=UserPublic, status_code=status.HTTP_200_OK)
+def get_user_profile(id: str, db: Session = Depends(get_db)) -> UserPublic:
+    """Return a user's public profile by ID."""
+    db_user = get_user_by_id(db, id)
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+    return db_user
+
+
+@router.put("/{id}", response_model=UserUpdateResponse, status_code=status.HTTP_200_OK)
+def update_user_profile(
+    id: str,
+    user_update: UserUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserUpdateResponse:
+    """Update the authenticated user's own profile."""
+    require_same_user(id, current_user)
+
+    db_user = get_user_by_id(db, id)
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    if user_update.email and user_update.email != db_user.email:
+        existing_user = get_user_by_email(db, user_update.email)
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email is already in use",
+            )
+
+    updated_user = update_user(db, db_user, user_update)
+    return UserUpdateResponse(success=True, user=updated_user)
+
+
+@router.delete("/{id}", response_model=MessageResponse, status_code=status.HTTP_200_OK)
+def delete_user_account(
+    id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> MessageResponse:
+    """Delete the authenticated user's own account."""
+    require_same_user(id, current_user)
+
+    db_user = get_user_by_id(db, id)
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    delete_user(db, db_user)
+    return MessageResponse(success=True, message="User account deleted successfully")

--- a/backend/src/app/schemas/token.py
+++ b/backend/src/app/schemas/token.py
@@ -1,0 +1,18 @@
+"""Pydantic schemas related to JWT tokens."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    """Simple token response model."""
+
+    token: str
+
+
+class TokenData(BaseModel):
+    """Decoded token payload data."""
+
+    sub: str
+    role: str

--- a/backend/src/app/schemas/user.py
+++ b/backend/src/app/schemas/user.py
@@ -1,0 +1,69 @@
+"""Pydantic schemas for user requests and responses."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from app.models.user import UserRole
+
+
+class UserRegister(BaseModel):
+    """Request body for user registration."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    email: EmailStr
+    password: str = Field(..., min_length=6, max_length=255)
+    role: UserRole
+
+
+class UserLogin(BaseModel):
+    """Request body for user login."""
+
+    email: EmailStr
+    password: str = Field(..., min_length=1, max_length=255)
+
+
+class UserUpdate(BaseModel):
+    """Request body for updating a user's profile."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    email: EmailStr | None = None
+    bio: str | None = Field(default=None, max_length=2000)
+
+
+class UserPublic(BaseModel):
+    """Public-safe user response model."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    email: EmailStr
+    role: UserRole
+    bio: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AuthResponse(BaseModel):
+    """Successful auth response returned on register/login."""
+
+    success: bool = True
+    token: str
+    user: UserPublic
+
+
+class UserUpdateResponse(BaseModel):
+    """Successful user update response."""
+
+    success: bool = True
+    user: UserPublic
+
+
+class MessageResponse(BaseModel):
+    """Generic success response with a message."""
+
+    success: bool = True
+    message: str


### PR DESCRIPTION
## Summary
Implements authentication and user functionality for the GigLink backend.

## Changes
- added User SQLAlchemy model
- added Pydantic schemas for User and Token
- implemented User repository CRUD functions
- implemented JWT authentication helpers
- added auth endpoints:
  - POST /api/auth/register
  - POST /api/auth/login
- added user endpoints:
  - GET /api/users/{id}
  - PUT /api/users/{id}
  - DELETE /api/users/{id}
- enforced same-user authorization for update and delete operations
- updated API routing to include auth and user routes

## Notes
- passwords are hashed before storage
- JWT Bearer authentication is used for protected user routes
- users can only modify their own account data

## Testing
- tested register flow
- tested login flow
- tested protected user routes with Bearer token
- verified same-user restriction for update/delete

## Issues
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20